### PR TITLE
Add PHP 7.4 pre-testing to travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ sudo: false
 php:
   - 5.6
   - 7.0
+  - 7.4
   - nightly
 
 before_script:
@@ -22,4 +23,5 @@ after_success:
 
 matrix:
   allow_failures:
+    - php: 7.4
     - php: nightly


### PR DESCRIPTION
We should be able to see if PHP 7.4 fails in the tests.